### PR TITLE
Estructura base de FlowPro con Express y Vue

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node backend/server.js

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# flowpro
+# FlowPro
+
+Estructura base con un backend en Express y frontend con Vue + Rete.js.
+
+## Scripts
+
+- `npm run dev`: inicia frontend y backend de forma concurrente.
+- `npm run dev:backend`: solo backend.
+- `npm run dev:frontend`: solo frontend.

--- a/backend/config/nodoChatbot.json
+++ b/backend/config/nodoChatbot.json
@@ -1,0 +1,5 @@
+{
+  "nombre": "Chatbot",
+  "descripcion": "Nodo para chatbots",
+  "version": "1.0.0"
+}

--- a/backend/config/nodoSeguimiento.json
+++ b/backend/config/nodoSeguimiento.json
@@ -1,0 +1,5 @@
+{
+  "nombre": "Seguimiento",
+  "descripcion": "Nodo para seguimiento de usuarios",
+  "version": "1.0.0"
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,54 @@
+// Servidor Express para exponer los nodos desde archivos JSON
+// Se busca mantener el código modular y legible
+
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+// Configuración centralizada
+const CONFIG = {
+  PORT: process.env.PORT || 3000,
+  CONFIG_DIR: path.join(__dirname, 'config'),
+};
+
+/**
+ * Lee y parsea un archivo JSON de configuración.
+ * @param {string} filename Nombre del archivo dentro del directorio de config
+ * @returns {object|null} Objeto con la configuración o null si falla
+ */
+function leerConfig(filename) {
+  try {
+    const ruta = path.join(CONFIG.CONFIG_DIR, filename);
+    const contenido = fs.readFileSync(ruta, 'utf-8');
+    return JSON.parse(contenido);
+  } catch (error) {
+    console.error(`Error al leer ${filename}:`, error.message);
+    return null;
+  }
+}
+
+/**
+ * Crea y configura la aplicación Express
+ * @returns {express.Application}
+ */
+function crearServidor() {
+  const app = express();
+
+  app.get('/config/:nodo', (req, res) => {
+    const nombreArchivo = `nodo${req.params.nodo}.json`;
+    const datos = leerConfig(nombreArchivo);
+    if (datos) {
+      res.json(datos);
+    } else {
+      res.status(404).json({ error: 'Configuración no encontrada' });
+    }
+  });
+
+  return app;
+}
+
+// Inicialización del servidor
+const app = crearServidor();
+app.listen(CONFIG.PORT, () => {
+  console.log(`Servidor escuchando en el puerto ${CONFIG.PORT}`);
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FlowPro</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/main.js"></script>
+</body>
+</html>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,7 @@
+<template>
+  <Editor />
+</template>
+
+<script setup>
+import Editor from './components/Editor.vue';
+</script>

--- a/frontend/src/components/Editor.vue
+++ b/frontend/src/components/Editor.vue
@@ -1,0 +1,30 @@
+<template>
+  <div ref="container" class="editor-container"></div>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue';
+import { NodeEditor } from 'rete';
+
+const container = ref(null);
+
+function inicializarEditor(el) {
+  const editor = new NodeEditor('demo@0.1.0', el);
+  // Aquí se podría configurar Rete con nodos y controles
+  return editor;
+}
+
+onMounted(() => {
+  if (container.value) {
+    inicializarEditor(container.value);
+  }
+});
+</script>
+
+<style scoped>
+.editor-container {
+  width: 100%;
+  height: 600px;
+  border: 1px solid #ccc;
+}
+</style>

--- a/frontend/src/components/controls/SelectControl.vue
+++ b/frontend/src/components/controls/SelectControl.vue
@@ -1,0 +1,20 @@
+<template>
+  <select v-model="selected">
+    <option v-for="option in options" :key="option" :value="option">
+      {{ option }}
+    </option>
+  </select>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+
+const props = defineProps({
+  options: {
+    type: Array,
+    default: () => [],
+  },
+});
+
+const selected = ref(props.options[0] || '');
+</script>

--- a/frontend/src/components/controls/TextareaControl.vue
+++ b/frontend/src/components/controls/TextareaControl.vue
@@ -1,0 +1,9 @@
+<template>
+  <textarea v-model="text"></textarea>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+
+const text = ref('');
+</script>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,5 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+const app = createApp(App);
+app.mount('#app');

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  root: __dirname,
+  server: {
+    port: 5173,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "flowpro",
+  "version": "1.0.0",
+  "description": "Proyecto con backend Express y frontend Vue + Rete.js",
+  "main": "backend/server.js",
+  "scripts": {
+    "dev:backend": "node backend/server.js",
+    "dev:frontend": "vite --config frontend/vite.config.js",
+    "dev": "concurrently \"npm run dev:backend\" \"npm run dev:frontend\""
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.2",
+    "vite": "^4.3.9",
+    "vue": "^3.4.21",
+    "rete": "^1.4.4"
+  }
+}


### PR DESCRIPTION
## Summary
- iniciar proyecto con `backend/` y `frontend/` según lo indicado
- implementar servidor Express modular que lee configuraciones JSON
- crear config de nodos `nodoChatbot.json` y `nodoSeguimiento.json`
- montar frontend con Vite, Vue y Rete.js
- incluir componentes y controles básicos
- añadir scripts npm para ejecutar frontend y backend
- agregar Procfile para despliegue

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_685542c48d988328a88c633b0b6e7cfa