### PR TITLE
Fix missing Vue plugin in Heroku build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,6 @@
 // vite.config.js
 import { defineConfig } from 'vite';
-import vue from '@vitejs/plugin-vue';
+import { createVuePlugin as vue } from 'vite-plugin-vue2';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 


### PR DESCRIPTION
## Summary
- replace `@vitejs/plugin-vue` with `vite-plugin-vue2`

## Testing
- `npm ls vite-plugin-vue2`

------
https://chatgpt.com/codex/tasks/task_e_68557949a100832880a701f1e62d2b5e